### PR TITLE
feat(audio): expose VOIP_TX_OBSERVE in MediaRecorder + AudioRecord

### DIFF
--- a/media/java/android/media/AudioAttributes.java
+++ b/media/java/android/media/AudioAttributes.java
@@ -1291,6 +1291,8 @@ public final class AudioAttributes implements Parcelable {
                     || (preset == MediaRecorder.AudioSource.VOICE_CALL)
                     || (preset == MediaRecorder.AudioSource.ECHO_REFERENCE)
                     || (preset == MediaRecorder.AudioSource.ULTRASOUND)
+                    // Wafer fork: virtual source for system VoIP tx observation.
+                    || (preset == MediaRecorder.AudioSource.VOIP_TX_OBSERVE)
                     // AUDIO_SOURCE_INVALID is used by convention on default initialized
                     // audio attributes
                     || (preset == MediaRecorder.AudioSource.AUDIO_SOURCE_INVALID)) {

--- a/media/java/android/media/AudioRecord.java
+++ b/media/java/android/media/AudioRecord.java
@@ -1026,7 +1026,8 @@ public class AudioRecord implements AudioRouting, MicrophoneDirection,
                         || source == MediaRecorder.AudioSource.VOICE_DOWNLINK
                         || source == MediaRecorder.AudioSource.VOICE_UPLINK
                         || source == MediaRecorder.AudioSource.VOICE_CALL
-                        || source == MediaRecorder.AudioSource.ECHO_REFERENCE) {
+                        || source == MediaRecorder.AudioSource.ECHO_REFERENCE
+                        || source == MediaRecorder.AudioSource.VOIP_TX_OBSERVE) {
                     throw new UnsupportedOperationException(
                             "Cannot request private capture with source: " + source);
                 }
@@ -1152,7 +1153,9 @@ public class AudioRecord implements AudioRouting, MicrophoneDirection,
                     && (audioSource != MediaRecorder.AudioSource.RADIO_TUNER)
                     && (audioSource != MediaRecorder.AudioSource.ECHO_REFERENCE)
                     && (audioSource != MediaRecorder.AudioSource.HOTWORD)
-                    && (audioSource != MediaRecorder.AudioSource.ULTRASOUND))) {
+                    && (audioSource != MediaRecorder.AudioSource.ULTRASOUND)
+                    // Wafer fork: virtual source for system VoIP tx observation.
+                    && (audioSource != MediaRecorder.AudioSource.VOIP_TX_OBSERVE))) {
             throw new IllegalArgumentException("Invalid audio source " + audioSource);
         }
         mRecordSource = audioSource;

--- a/media/java/android/media/MediaRecorder.java
+++ b/media/java/android/media/MediaRecorder.java
@@ -422,6 +422,27 @@ public class MediaRecorder implements AudioRouting,
         @RequiresPermission(android.Manifest.permission.ACCESS_ULTRASOUND)
         public static final int ULTRASOUND = 2000;
 
+        /**
+         * Wafer fork: system-level observer of the user's microphone during
+         * another app's active VoIP call (audio mode
+         * MODE_IN_COMMUNICATION). Permission-gated by
+         * {@link android.Manifest.permission#CAPTURE_AUDIO_OUTPUT} —
+         * platform components only.
+         *
+         * <p>Treated as a virtual source on the audio policy side so per-track
+         * silencing rules do not apply. Rides alongside the call app's own
+         * microphone capture without disrupting it.
+         *
+         * <p>Intentionally not annotated {@code @SystemApi}; consumers reach
+         * this constant via {@code platform_apis: true} on the platform
+         * classpath, so the SystemApi @FlaggedApi lint requirement does not
+         * apply. Marked {@code @hide} so it is excluded from public/system
+         * stubs entirely.
+         *
+         * @hide
+         */
+        public static final int VOIP_TX_OBSERVE = 2001;
+
     }
 
     /** @hide */
@@ -457,6 +478,7 @@ public class MediaRecorder implements AudioRouting,
         AudioSource.RADIO_TUNER,
         AudioSource.HOTWORD,
         AudioSource.ULTRASOUND,
+        AudioSource.VOIP_TX_OBSERVE,
     })
     @Retention(RetentionPolicy.SOURCE)
     public @interface SystemSource {}
@@ -507,6 +529,7 @@ public class MediaRecorder implements AudioRouting,
             case AudioSource.RADIO_TUNER:
             case AudioSource.HOTWORD:
             case AudioSource.ULTRASOUND:
+            case AudioSource.VOIP_TX_OBSERVE:
                 return true;
             default:
                 return false;
@@ -546,6 +569,8 @@ public class MediaRecorder implements AudioRouting,
                 return "HOTWORD";
             case AudioSource.ULTRASOUND:
                 return "ULTRASOUND";
+            case AudioSource.VOIP_TX_OBSERVE:
+                return "VOIP_TX_OBSERVE";
             case AudioSource.AUDIO_SOURCE_INVALID:
                 return "AUDIO_SOURCE_INVALID";
             default:

--- a/media/jni/android_media_MediaRecorder.cpp
+++ b/media/jni/android_media_MediaRecorder.cpp
@@ -214,7 +214,9 @@ android_media_MediaRecorder_setAudioSource(JNIEnv *env, jobject thiz, jint as)
 {
     ALOGV("setAudioSource(%d)", as);
     if (as < AUDIO_SOURCE_DEFAULT ||
-        (as >= AUDIO_SOURCE_CNT && as != AUDIO_SOURCE_FM_TUNER)) {
+        (as >= AUDIO_SOURCE_CNT
+            && as != AUDIO_SOURCE_FM_TUNER
+            && as != AUDIO_SOURCE_VOIP_TX_OBSERVE)) {
         jniThrowException(env, "java/lang/IllegalArgumentException", "Invalid audio source");
         return;
     }


### PR DESCRIPTION
## Summary

Surface the new virtual audio source 2001 in the Java + JNI APIs. `@hide` constant — system-only. Not `@SystemApi` (avoids `@FlaggedApi` lint requirement; the platform-signed launcher accesses via `platform_apis = true`).

## What changes

- `MediaRecorder.AudioSource.VOIP_TX_OBSERVE = 2001` (`@hide`)
- `@SystemSource` IntDef + `isValidAudioSource` + `toLogFriendlyAudioSource` helpers
- `AudioAttributes.Builder.setInternalCapturePreset` whitelist
- `AudioRecord.audioParamCheck` whitelist (otherwise `mSource → -1` fatal)
- `AudioRecord.setPrivacySensitive` throwlist (mirrors `ECHO_REFERENCE`)
- JNI `android_media_MediaRecorder.cpp` invalid-source guard exception

Companion commits in `system/media`, `system/hardware/interfaces`, and `frameworks/av` define the enum + AIDL + audio-policy implementation.

## Companion PRs

Tracking + design context: **wafer-inc/project-switchboard#289**

🤖 Generated with [Claude Code](https://claude.com/claude-code)