### PR TITLE
Suppress FGS notification for Wafer wakeword mic service [WAF-638]

### DIFF
--- a/services/core/java/com/android/server/am/ActiveServices.java
+++ b/services/core/java/com/android/server/am/ActiveServices.java
@@ -3044,6 +3044,20 @@ public final class ActiveServices {
             notification.flags |= Notification.FLAG_FOREGROUND_SERVICE;
             sr.foregroundNoti = notification;
 
+            // Wafer: the always-on "okay computer" wakeword service must hold an
+            // FGS microphone notification to keep background mic access, but we
+            // don't want it cluttering the shade. Suppress its display while
+            // keeping the service foreground — UPDATE_ONLY never surfaces a
+            // not-yet-visible notification, and there is no post-notification
+            // enforcement that would kill the service for it. The green mic
+            // privacy indicator is AppOps-driven and stays visible.
+            if ("com.wafer.launcher".equals(pkg)
+                    && (sr.foregroundServiceType
+                            & ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE) != 0) {
+                sr.mFgsNotificationDeferred = false;
+                return ServiceNotificationPolicy.UPDATE_ONLY;
+            }
+
             // ...and determine immediate vs deferred display policy for it
             final boolean showNow = shouldShowFgsNotificationLocked(sr);
             if (showNow) {


### PR DESCRIPTION
## Suppress the FGS notification for the Wafer wakeword mic service (WAF-638)

The always-on "okay computer" wakeword service (`com.wafer.launcher`,
`WakewordService`, `FOREGROUND_SERVICE_TYPE_MICROPHONE`) must hold an FGS
notification to keep background mic access, but the persistent "Listening for
okay computer" chip in the shade is unwanted and **can't be removed app-side**
— an always-on FGS notification can't be made transient without dropping
foreground (which revokes the mic).

**Change:** in `ActiveServices.applyForegroundServiceNotificationLocked()`,
return `UPDATE_ONLY` for that package + mic FGS type. The notification is still
posted and tracked, but `UPDATE_ONLY` never surfaces a not-yet-visible
notification, so it never appears. The service stays foreground (no
post-notification enforcement kills it). The green **mic privacy indicator is
AppOps-driven and unaffected** — it stays visible while the mic is live.

Pairs with the launcher (wafer-inc/WaferLauncher#29) and switchboard
(wafer-inc/project-switchboard#395) sides of the wakeword feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsaAvMhdJbV3vbaYDEuWcr
